### PR TITLE
[TASK] Upgrade to Node.js 18 in DDEV

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -13,7 +13,7 @@ mutagen_enabled: true
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
-nodejs_version: "16"
+nodejs_version: "18"
 timezone: "Europe/Berlin"
 composer-version: "2"
 omit_containers: [db, dba, ddev-ssh-agent]


### PR DESCRIPTION
We're not using Node.js here. Still, we should use the latest LTS version as a matter of principle.