### PR TITLE
[BUGFIX] Downgrade DDEV to Node.js 16

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -13,7 +13,7 @@ mutagen_enabled: true
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
-nodejs_version: "18"
+nodejs_version: "16"
 timezone: "Europe/Berlin"
 composer-version: "2"
 omit_containers: [db, dba, ddev-ssh-agent]


### PR DESCRIPTION
Node.js 18 prevents a container start on some macOS systems.

This reverts commit c37c10b47930a3809e57eb4e22601e62c0f509ef.