### PR TITLE
[TASK] Drop `squizlabs/php_codesniffer`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
           - composer:normalize
           - composer:psr-verify
           - php:fixer
-          - php:sniff
           - php:stan
           - yaml:lint
         php-version:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
 		"phpstan/phpstan-phpunit": "^1.3.14",
 		"phpstan/phpstan-strict-rules": "^1.5.1",
 		"phpunit/phpunit": "^10.3.4",
-		"squizlabs/php_codesniffer": "^3.7.2",
 		"symfony/yaml": "^6.3.3",
 		"typo3/coding-standards": "^0.7.1"
 	},
@@ -69,12 +68,10 @@
 		"ci:php": [
 			"@ci:php:fixer",
 			"@ci:php:lint",
-			"@ci:php:sniff",
 			"@ci:php:stan"
 		],
 		"ci:php:fixer": "php-cs-fixer fix --dry-run -v --show-progress=dots",
 		"ci:php:lint": "find .*.php src tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-		"ci:php:sniff": "phpcs src tests",
 		"ci:php:stan": "phpstan --no-progress",
 		"ci:static": [
 			"@ci:composer",
@@ -91,11 +88,9 @@
 		],
 		"fix:composer": "@composer normalize",
 		"fix:php": [
-			"@fix:php:cs",
-			"@fix:php:sniff"
+			"@fix:php:cs"
 		],
 		"fix:php:cs": "php-cs-fixer fix --config .php-cs-fixer.php",
-		"fix:php:sniff": "phpcbf src tests",
 		"phpstan:baseline": "phpstan --generate-baseline=phpstan-baseline.neon --allow-empty-baseline"
 	},
 	"scripts-descriptions": {
@@ -106,7 +101,6 @@
 		"ci:php": "Runs all static checks for PHP files.",
 		"ci:php:fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
 		"ci:php:lint": "Lints the PHP files for syntax errors.",
-		"ci:php:sniff": "Checks the code style with PHP_CodeSniffer (PHPCS).",
 		"ci:php:stan": "Checks the PHP types using PHPStan.",
 		"ci:static": "Runs all static code checks (syntax, style, types).",
 		"ci:tests:all": "Runs all PHPUnit tests (unit and functional).",
@@ -117,7 +111,6 @@
 		"fix:composer": "Normalizes all composer.json files.",
 		"fix:php": "Runs all fixers for the PHP code.",
 		"fix:php:cs": "Fixes the code style with PHP-CS-Fixer.",
-		"fix:php:sniff": "Fixes the code style with PHP_CodeSniffer.",
 		"phpstan:baseline": "Updates the PHPStan baseline file to match the code."
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32bd1d83d7bfe8f38d169422bedffa41",
+    "content-hash": "04dfab15447f83e2eef943bb5dea5332",
     "packages": [
         {
             "name": "psr/container",
@@ -3472,63 +3472,6 @@
             "time": "2023-02-07T11:34:05+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
-            "keywords": [
-                "phpcs",
-                "standards",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-            },
-            "time": "2023-02-22T23:07:41+00:00"
-        },
-        {
             "name": "symfony/event-dispatcher",
             "version": "v6.3.2",
             "source": {
@@ -4378,5 +4321,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
The PSR-12 rule set conflicts with our PHP-CS-Fixer rules.