### PR TITLE
[TASK] Use the development PHP INI on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
+          ini-file: development
           coverage: none
           tools: composer:v2
 
@@ -52,6 +53,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: none
           tools: composer:v2
 
@@ -87,6 +89,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: none
           tools: composer:v2
 
@@ -128,6 +131,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: none
           tools: composer:v2
 


### PR DESCRIPTION
This will allow us to see (and error out on) all
warnings and notices.

Fixes #197